### PR TITLE
Remove long-deprecated <browser:layer> configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ CHANGES
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove long-deprecated <browser:layer> configuration which was hidden
+  behind a ``have deprecatedlayers`` condition. That directive simply
+  doesn't exist any longer and defining that feature would cause an
+  "Unknown directive" ConfigurationError.
 
 
 4.0.0 (2017-04-27)

--- a/src/zope/app/rotterdam/configure.zcml
+++ b/src/zope/app/rotterdam/configure.zcml
@@ -3,14 +3,6 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:zcml="http://namespaces.zope.org/zcml">
 
-  <!-- BBB 2006/02/18, to be removed after 12 months -->
-  <browser:layer
-      zcml:condition="have deprecatedlayers"
-      name="rotterdam"
-      interface="zope.app.rotterdam.rotterdam"
-      bbb_aware="true"
-      />
-
   <interface
       interface="zope.app.rotterdam.Rotterdam"
       type="zope.publisher.interfaces.browser.IBrowserSkinType"


### PR DESCRIPTION
This was hidden behind a ``have deprecatedlayers`` condition. But that directive simply doesn't exist any longer and defining that feature would cause an "Unknown directive" ConfigurationError.

This causes issues with zope.app.apidoc which wants to pretend that all conditions are always true.